### PR TITLE
Add Pet modal

### DIFF
--- a/components/PetModal.vue
+++ b/components/PetModal.vue
@@ -1,0 +1,287 @@
+<template>
+    <b-modal
+        :id="id"
+        ok-title="Save"
+        @ok="submitForm"
+        size="lg"
+        @show="initModal"
+        @shown="editMode && getPetData()"
+        @hidden="resetModal"
+    >
+        <!-- Title -->
+        <template #modal-title>
+            <span class="font-weight-bold">{{ editMode ? `${$t('title.pet_update')} ${petId}` : $t('title.pet_upload') }}</span>
+        </template>
+        <!-- Content -->
+        <b-overlay :show="loading" rounded="lg">
+            <b-form ref="pet-form" @submit.stop.prevent="handleSubmit">
+                <div class="row">
+                    <b-form-group
+                        id="input-group-1"
+                        :label="$t('pages.pets.name')"
+                        label-for="name"
+                        :invalid-feedback="$t('pages.pets.invalid_feedback')"
+                        class="col-6"
+                    >
+                        <b-form-input
+                            id="name"
+                            v-model="petData.name"
+                            placeholder=""
+                            :state="nameState"
+                            required
+                        ></b-form-input>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-2"
+                        :label="$t('pages.pets.age')"
+                        label-for="age"
+                        :invalid-feedback="$t('pages.pets.invalid_feedback')"
+                        class="col-3"
+                    >
+                        <b-form-input
+                            id="age"
+                            v-model="petData.age"
+                            :state="ageState"
+                            type="number"
+                            required
+                        ></b-form-input>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-4"
+                        :label="$t('pages.pets.gender')"
+                        label-for="gender"
+                        :invalid-feedback="$t('pages.pets.invalid_feedback')"
+                        class="col-3"
+                    >
+                        <b-form-select
+                            id="gender"
+                            v-model="petData.gender"
+                            placeholder=""
+                            :state="genderState"
+                            required
+                            :options="[{value: 'male', text: 'Male'},{value: 'female', text: 'Female'}]"
+                        ></b-form-select>
+                    </b-form-group>
+                </div>
+                <div class="row border-bottom">
+                    <b-form-group
+                        id="input-group-3"
+                        :label="$t('pages.pets.avatar')"
+                        label-for="avatar"
+                        :invalid-feedback="$t('pages.pets.invalid_feedback')"
+                        class="col-12"
+                    >
+                        <b-form-input
+                            id="avatar"
+                            v-model="petData.avatar"
+                            :placeholder="$t('pages.pets.avatar_placeholder')"
+                            :state="avatarState"
+                            required
+                        ></b-form-input>
+                    </b-form-group>
+                </div>
+                <div class="row mt-4">
+                    <b-form-group
+                        id="input-group-5"
+                        :label="$t('pages.pets.breed')"
+                        label-for="breed"
+                        class="col-3"
+                    >
+                        <b-form-input
+                            id="breed"
+                            v-model="petData.breed"
+                            placeholder=""
+                        ></b-form-input>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-6"
+                        :label="$t('pages.pets.type')"
+                        label-for="type"
+                        class="col-3"
+                    >
+                        <b-form-select
+                            id="type"
+                            v-model="petData.type"
+                            placeholder=""
+                            :options="[{value: 'dog', text: 'Dog'}, {value: 'cat', text: 'Cat'}]"
+                        ></b-form-select>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-7"
+                        :label="$t('pages.pets.delivery_type')"
+                        label-for="type_delivery"
+                        class="col-3"
+                    >
+                        <b-form-select
+                            id="type_delivery"
+                            v-model="petData.type_delivery"
+                            placeholder=""
+                            :options="[{value: 'adopt', text: 'Adopt'}, {value: 'sale', text: 'For sale'}]"
+                        ></b-form-select>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-8"
+                        :label="$t('pages.pets.status')"
+                        label-for="status"
+                        class="col-3"
+                    >
+                        <b-form-select
+                            id="status"
+                            v-model="petData.status"
+                            placeholder=""
+                            :options="[{value: 'adopted', text: 'Adopted'}, {value: 'available', text: 'Available'}]"
+                        ></b-form-select>
+                    </b-form-group>
+                </div>
+                <div class="row">
+                    <b-form-group
+                        id="input-group-9"
+                        :label="$t('pages.pets.color')"
+                        label-for="color"
+                        class="col-3"
+                    >
+                        <b-form-input
+                            id="color"
+                            v-model="petData.color"
+                            placeholder=""
+                        ></b-form-input>
+                    </b-form-group>
+                    <b-form-group
+                        id="input-group-10"
+                        :label="$t('pages.pets.description')"
+                        label-for="description"
+                        class="col-9"
+                    >
+                        <b-form-input
+                            id="description"
+                            v-model="petData.description"
+                            placeholder=""
+                        ></b-form-input>
+                    </b-form-group>
+                </div>
+                
+                
+            </b-form>
+        </b-overlay>
+    </b-modal>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+const defaultPetData = {
+    avatar: '',
+    name: '',
+    age: '',
+    gender: 'male',
+    color: '',
+    type: 'cat',
+    status: 'available',
+    type_delivery: 'adopt',
+    description: '',
+    breed: '',
+}
+export default {
+    props: {
+        id: {
+            type: String,
+            required: true,
+        },
+        editMode: Boolean,
+        petId: String,
+    },
+    data() {
+        return {
+            petData: { ...defaultPetData },
+            avatarState: null,
+            nameState: null,
+            ageState: null,
+            genderState: null,
+            loading: false,
+        };
+    },
+    computed: {
+        ...mapState({
+            token: state => state.moduleAuth.token, 
+        }),
+    },
+    methods: {
+        initModal() {
+            this.resetModal();
+            this.$axios.setToken(this.token, 'Bearer');
+        },
+        async getPetData() {
+            let response;
+            this.loading = true;
+            try {
+                response = await this.$axios.$get(`/pets/${this.petId}`);
+            } catch(err) {
+                this.$toasted.show(this.$t('alerts.pet_failed'), {
+                    type: 'error',
+                    duration: 4000,  
+                });
+            }
+            this.petData = response.pet;
+            this.loading = false;
+        },
+        checkFormValidity() {
+            const valid = this.$refs['pet-form'].checkValidity();
+            this.nameState = valid || this.petData.name.length > 0;
+            this.avatarState = valid || this.petData.avatar.length > 0;
+            this.ageState = valid || this.petData.age > 0;
+            this.genderState = valid || this.petData.gender.length > 0;
+            return valid;
+        },
+        resetModal() {
+            this.petData = { ...defaultPetData };
+            this.avatarState = null;
+            this.nameState = null;
+            this.ageState = null;
+            this.genderState = null;
+        },
+        async submitForm(event) {
+            event.preventDefault();
+            await this.handleSubmit();
+        },
+        async handleSubmit() {
+            if (!this.checkFormValidity()) {
+                return
+            }
+            // call API to create pet
+            let response;
+            this.loading = true;
+            try {
+                if (this.editMode) {
+                    response = await this.$axios.$put(
+                        `/pets/${this.petId}`,
+                        this.petData,
+                    );
+                } else {
+                    response = await this.$axios.$post(
+                        '/pets',
+                        this.petData,
+                    );
+                }
+            } catch (error) {
+                this.$toasted.show(this.$t('alerts.failed'), {
+                    type: 'error',
+                    duration: 4000,  
+                });
+                this.loading = false;
+                return;
+            }
+            this.loading = false;
+
+            this.$toasted.show(this.$t('alerts.success'), {
+                type: 'success',
+                duration: 4000,  
+            });
+            
+            // Hide the modal
+            this.$nextTick(() => {
+                this.$bvModal.hide(this.id);
+            });
+        },
+    },
+}
+</script>

--- a/locales/en.json
+++ b/locales/en.json
@@ -15,7 +15,9 @@
   },
   "title": {
     "register": "Register",
-    "login": "Login"
+    "login": "Login",
+    "pet_update": "Update pet data",
+    "pet_upload": "Upload your pet"
   },
   "message": {
     "welcome": "Welcome to App !!!",
@@ -33,6 +35,29 @@
       "username": "User name",
       "email": "Email",
       "created_at": "Created at"
+    },
+    "pets": {
+      "name": "Name",
+      "age": "Age",
+      "gender": "Gender",
+      "avatar": "Avatar",
+      "breed": "Breed",
+      "type": "Type",
+      "delivery_type": "Delivery Type",
+      "status": "Status",
+      "color": "Color",
+      "description": "Description",
+      "invalid_feedback": "This field is required",
+      "avatar_placeholder": "Link to avatar"
     }
+  },
+  "alerts": {
+    "success": "Updated successfully",
+    "failed": "Update failed",
+    "pet_failed": "Cannot fetch pet data"
+  },
+  "common": {
+    "create": "Create",
+    "edit": "Edit"
   }
 }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -49,7 +49,7 @@ module.exports = {
   },
 
   toast: {
-    position: 'top-center',
+    position: 'top-right',
     theme: 'bubble',
     duration: 5000,
   },

--- a/pages/pets.vue
+++ b/pages/pets.vue
@@ -1,0 +1,44 @@
+<template>
+    <div class="container">
+        <b-button variant="primary" @click="createPet()">{{ $t('common.create') }}</b-button>
+        <b-button variant="info" @click="editPet('170')">{{ $t('common.edit') }}</b-button>
+        <pet-modal :edit-mode="modal.editMode" id="pet-modal" :pet-id="modal.petId"/>
+    </div>
+</template>
+
+<script>
+import PetModal from '~/components/PetModal.vue';
+
+const defaultModalData = {
+    editMode: false,
+    petId: null,
+};
+
+export default {
+    middleware: ['check_auth', 'auth'],
+    components: {
+        PetModal
+    },
+    data() {
+        return {
+            modal: { ...defaultModalData },
+        };
+    },
+    methods: {
+        resetModal() {
+            this.modal = { ...defaultModalData };
+        },
+        createPet() {
+            this.resetModal();
+            this.$bvModal.show('pet-modal');
+        },
+        editPet(petId) {
+            this.modal = {
+                editMode: true,
+                petId,
+            };
+            this.$bvModal.show('pet-modal');
+        },
+    },
+}
+</script>


### PR DESCRIPTION
- Add PetModal component (used to create and update pet data)
- Props:
  - `id`: modal id (must be unique)
  - `edit-mode`: if the modal is used for creating a new pet, set it to `false`, else `true` for editing pet data 
  - `pet-id` (optional): the pet id to edit data
- Usage:
  - `this.$bvModal.show(modal_id)`
  - `this.$bvModal.hide(modal_id)`
- Test in route: `/pets`